### PR TITLE
Sample and tows calculated for sexed fish combined

### DIFF
--- a/R/getComps.R
+++ b/R/getComps.R
@@ -123,7 +123,8 @@ getcomps_long <- function(data, towstrat, type,
     warning("SEX was missing from the data and set to 'U' for unsexed fish")
   }
   if (is.character(data[, sexn])) {
-    data[, sexn] <- factor(data[, sexn], levels = c("F", "M", "U"))
+    data$SEX[data$SEX %in% c("M", "F")] <- "B"
+    data[, sexn] <- factor(data[, sexn], levels = c("B", "U"))
   }
 
   # FREQ... stores the number of fish that sum to the weightid
@@ -146,6 +147,7 @@ getcomps_long <- function(data, towstrat, type,
       list("tows" = data[, towid], "ONLY_U_TOWS" = data[, c("Uonly")]),
       by = data[, tstratwsex, drop = FALSE],
       lenique, drop = dropmissing))
+
   comp <- merge(
     stats::reshape(comp, timevar = "SEX", idvar = Cstrat, direction = "wide"),
     stats::aggregate(
@@ -154,23 +156,28 @@ getcomps_long <- function(data, towstrat, type,
       lenique, drop = dropmissing),
     by = towstrat, all.x = TRUE)
 
-  if(length(grep("ONLY_U_TOWS.F|ONLY_U_TOWS.M", colnames(comp))) > 0){
-    comp <- comp[, -grep("ONLY_U_TOWS.F|ONLY_U_TOWS.M", colnames(comp))]
+
+  #if(length(grep("ONLY_U_TOWS.F|ONLY_U_TOWS.M", colnames(comp))) > 0){
+  #  comp <- comp[, -grep("ONLY_U_TOWS.F|ONLY_U_TOWS.M", colnames(comp))]
+  #}
+  if(length(grep("ONLY_U_TOWS.B", colnames(comp))) > 0){
+    comp <- comp[, -grep("ONLY_U_TOWS.B", colnames(comp))]
   }
   colnames(comp) <- gsub("(.+)\\.([A-Z])", "\\L\\2\\1", colnames(comp),
     perl = TRUE)
+  colnames(comp) <- gsub("b", "mf", colnames(comp))
   colnames(comp) <- gsub("freq|freq.+", "samps", colnames(comp),
     ignore.case = TRUE)
   colnames(comp) <- gsub("uonl.+", "ONLY_U_TOWS", colnames(comp),
     ignore.case = TRUE)
   colnames(comp) <- gsub(paste0("([a-z])", weightid), "\\1", colnames(comp),
     ignore.case = TRUE)
-  colnames(comp) <- gsub("^f$", "female", colnames(comp))
-  colnames(comp) <- gsub("^m$", "male", colnames(comp))
+  colnames(comp) <- gsub("^mf$", "female.male", colnames(comp))
+  #colnames(comp) <- gsub("^m$", "male", colnames(comp))
   colnames(comp) <- gsub("^u$", "unsexed", colnames(comp))
   # todo: remove legacy code of needing fishyr
-  colnames(comp) <- gsub("^YEAR$", "fishyr", colnames(comp),
-    ignore.case = TRUE)
+  #colnames(comp) <- gsub("^YEAR$", "fishyr", colnames(comp),
+  #  ignore.case = TRUE)
   comp[is.na(comp)] <- 0
   return(comp)
 }

--- a/R/getComps.R
+++ b/R/getComps.R
@@ -123,8 +123,7 @@ getcomps_long <- function(data, towstrat, type,
     warning("SEX was missing from the data and set to 'U' for unsexed fish")
   }
   if (is.character(data[, sexn])) {
-    data$SEX[data$SEX %in% c("M", "F")] <- "B"
-    data[, sexn] <- factor(data[, sexn], levels = c("B", "U"))
+    data[, sexn] <- factor(data[, sexn], levels = c("F", "M", "U"))
   }
 
   # FREQ... stores the number of fish that sum to the weightid
@@ -147,7 +146,6 @@ getcomps_long <- function(data, towstrat, type,
       list("tows" = data[, towid], "ONLY_U_TOWS" = data[, c("Uonly")]),
       by = data[, tstratwsex, drop = FALSE],
       lenique, drop = dropmissing))
-
   comp <- merge(
     stats::reshape(comp, timevar = "SEX", idvar = Cstrat, direction = "wide"),
     stats::aggregate(
@@ -156,28 +154,23 @@ getcomps_long <- function(data, towstrat, type,
       lenique, drop = dropmissing),
     by = towstrat, all.x = TRUE)
 
-
-  #if(length(grep("ONLY_U_TOWS.F|ONLY_U_TOWS.M", colnames(comp))) > 0){
-  #  comp <- comp[, -grep("ONLY_U_TOWS.F|ONLY_U_TOWS.M", colnames(comp))]
-  #}
-  if(length(grep("ONLY_U_TOWS.B", colnames(comp))) > 0){
-    comp <- comp[, -grep("ONLY_U_TOWS.B", colnames(comp))]
+  if(length(grep("ONLY_U_TOWS.F|ONLY_U_TOWS.M", colnames(comp))) > 0){
+    comp <- comp[, -grep("ONLY_U_TOWS.F|ONLY_U_TOWS.M", colnames(comp))]
   }
   colnames(comp) <- gsub("(.+)\\.([A-Z])", "\\L\\2\\1", colnames(comp),
     perl = TRUE)
-  colnames(comp) <- gsub("b", "mf", colnames(comp))
   colnames(comp) <- gsub("freq|freq.+", "samps", colnames(comp),
     ignore.case = TRUE)
   colnames(comp) <- gsub("uonl.+", "ONLY_U_TOWS", colnames(comp),
     ignore.case = TRUE)
   colnames(comp) <- gsub(paste0("([a-z])", weightid), "\\1", colnames(comp),
     ignore.case = TRUE)
-  colnames(comp) <- gsub("^mf$", "female.male", colnames(comp))
-  #colnames(comp) <- gsub("^m$", "male", colnames(comp))
+  colnames(comp) <- gsub("^f$", "female", colnames(comp))
+  colnames(comp) <- gsub("^m$", "male", colnames(comp))
   colnames(comp) <- gsub("^u$", "unsexed", colnames(comp))
   # todo: remove legacy code of needing fishyr
-  #colnames(comp) <- gsub("^YEAR$", "fishyr", colnames(comp),
-  #  ignore.case = TRUE)
+  colnames(comp) <- gsub("^YEAR$", "fishyr", colnames(comp),
+    ignore.case = TRUE)
   comp[is.na(comp)] <- 0
   return(comp)
 }

--- a/R/writeComps.R
+++ b/R/writeComps.R
@@ -153,16 +153,12 @@ writeComps = function(inComps, fname = NULL, abins = NULL, lbins = NULL,
   if(length(inComps$female) == 0) {
     inComps$female <- inComps$fsamps <- inComps$ftows <- 0
   }
+  if(length(inComps$both) == 0) {
+    inComps$both <- inComps$both <- inComps$both <- 0
+  }
   if(length(inComps$unsexed) == 0){
     inComps$unsexed <- inComps$usamps <- inComps$utows <- 0
   }
-
-  # Create a column that combines males and females
-  inComps$both   <- inComps$male + inComps$female
-  inComps$bothsamps <- inComps$msamps + inComps$fsamps
-  # All tows is all unique tows - unsure whether the line
-  # below should be ftows + mtows instead
-  inComps$bothtows  <- inComps$mtows + inComps$ftows #inComps$alltows
 
   # Fix length bins
   if ( !is.null(inComps$lengthcm) ) {
@@ -201,7 +197,7 @@ writeComps = function(inComps, fname = NULL, abins = NULL, lbins = NULL,
   } # End if for lbins
 
   # Fix age bins
-  if ( !is.null(inComps$Age) ) {
+  if (!is.null(inComps$Age)) {
     if ( is.null(abins) ) {
       if (verbose){
         cat("\nNo age bins provided, using data as-is\n\n")
@@ -261,6 +257,7 @@ writeComps = function(inComps, fname = NULL, abins = NULL, lbins = NULL,
 
   # Rename columns to be used below
   if(!AAL){
+    names(inComps)[which(names(inComps) == "both")] <- "b"
     names(inComps)[which(names(inComps) == "female")] <- "f"
     names(inComps)[which(names(inComps) == "male")]   <- "m"
     names(inComps)[which(names(inComps) == "unsexed")]<- "u"
@@ -286,7 +283,7 @@ writeComps = function(inComps, fname = NULL, abins = NULL, lbins = NULL,
   }
 
   # For each sex in turn
-  for ( g in c("m","f","u","both")) {
+  for ( g in c("m","f","u","b")) {
     myname <- g
     if (verbose) {
       cat(paste("Assembling, sex is:", myname, "\n"))
@@ -369,9 +366,9 @@ writeComps = function(inComps, fname = NULL, abins = NULL, lbins = NULL,
   }
 
   Ninput_b <- round(ifelse( 
-                      bothComps$Nsamps / bothComps$Ntows < 44,
-                      bothComps$Ntows + 0.138 * bothComps$Nsamps,
-                      7.06 * bothComps$Ntows), 0 )
+                      bComps$Nsamps / bComps$Ntows < 44,
+                      bComps$Ntows + 0.138 * bComps$Nsamps,
+                      7.06 * bComps$Ntows), 0 )
   Ninput_b[is.na(Ninput_b)] <- 0
   Ninput_f <- round(ifelse( 
                       fComps$Nsamps / fComps$Ntows < 44,
@@ -395,7 +392,7 @@ writeComps = function(inComps, fname = NULL, abins = NULL, lbins = NULL,
     } else {
       bins <- lbins_in
     }
-    FthenM <- cbind(uStrat, round(bothComps$Ntows, 0), round(bothComps$Nsamps, 0), Ninput_b,
+    FthenM <- cbind(uStrat, round(bComps$Ntows, 0), round(bComps$Nsamps, 0), Ninput_b,
                     fComps[,1:NCOLS], mComps[,1:NCOLS])
     index <- grep("Ninput", names(FthenM))
     names(FthenM)[(index + 1):ncol(FthenM)] <- c(paste0('F', bins), paste0("M", bins))


### PR DESCRIPTION
These new commits add columns in the comp data frame output by the {getComps } function that calculate a combined sample size and number of unique tows where fish were sexed (e.g., either F or M). The {writeComps} function now used the "both" column to determine the input effective sample size for the composition data formatted as sex = 3 in Stock Synthesis. The separate male and female comps use the corresponding sex specific sample sizes and tows to calculate the input effective sample size for those data frames.  The motivation for this change came from processing PacFIN data where there was a heavy mixture of sexed and unsexed data.  

The changes in the {getComps} worker function {getcomps_long} is not elegant but it works. I spent a large amount (slightly embarrassing) of time trying to do these calculation via the existing unsexed approach but could not get it to fully work. 