### PR TITLE
feat: add control of "month" in writeComps()

### DIFF
--- a/R/writeComps.R
+++ b/R/writeComps.R
@@ -29,13 +29,14 @@
 #'   fish are binned according to user specified bins irregardless of \code{maxAge}.
 #'   
 #' @param month Month for all observations. Defaults to 7. If input has multiple 
-#' seasons, this must be a vector of equal length to the number of seasons.
+#' seasons, this must be a vector of equal length to the maximum seasons.
 #' 
 #' @param partition  Used by Stock Synthesis for length- or age-composition data
 #' where 0 = retained + discarded, 1= discarded, and 2 = retained fish.
 #' The default is to assume that these fish are retained only.
 #' The default was changed in 2020 from a value of 0,
 #' and code should be updated accordingly if you really want 0.
+#' 
 #' @param ageErr     Defaults to 1.
 #' 
 #' @param dummybins A logical value specifying whether data outside of the
@@ -105,7 +106,7 @@ writeComps = function(inComps, fname = NULL, abins = NULL, lbins = NULL,
                       overwrite = TRUE, verbose = FALSE) {
 
   # Check month input vs seasons in data
-  if(max(inComps[["season"]]) != length(month)) {
+  if("season" %in% names(inComps) && max(inComps[["season"]]) != length(month)) {
     stop("Input 'month' should have length equal to the maximum season:",
     "\nmonth: ", month,
     "\nseasons: ", paste(sort(unique(inComps[["season"]])), collapse = " "))
@@ -356,7 +357,9 @@ writeComps = function(inComps, fname = NULL, abins = NULL, lbins = NULL,
   if (!"fishyr" %in% colnames(uStrat)) stop("fishyr should be a column")
   if (!"fleet"  %in% colnames(uStrat)) stop("fleet should be a column")
   uStrat <- data.frame(uStrat[, "fishyr"], 
-                       month = month[uStrat[, "season"]],
+                       month = ifelse("season" %in% names(inComps), 
+                                      month[uStrat[, "season"]],
+                                      month),
                        uStrat[, 'fleet'])
   colnames(uStrat) <-  c("year", "month", "fleet")
 

--- a/R/writeComps.R
+++ b/R/writeComps.R
@@ -10,8 +10,7 @@
 #' then sexes should be assigned as males and females by \code{\link{doSexRatio}}
 #' before using \code{writeComps}.
 #' 
-#' \strong{Failure to use \code{\link{doSexRatio}} will result in all unsexed fish being discarded.}
-#' }
+#' 
 #' 
 #' @export
 #'   
@@ -29,7 +28,10 @@
 #'   fish are binned according to user specified bins irregardless of \code{maxAge}.
 #'   
 #' @param month Month for all observations. Defaults to 7. If input has multiple 
-#' seasons, this must be a vector of equal length to the maximum seasons.
+#' seasons, this must be a vector of equal length to the maximum seasons where
+#' the order of months in the vector will be assigned to season in ascending order.
+#' For example, if there  are two seasons and the month = c(1, 7) season 1 will be 
+#' assigned to month 1 and season 2 to month 7.
 #' 
 #' @param partition  Used by Stock Synthesis for length- or age-composition data
 #' where 0 = retained + discarded, 1= discarded, and 2 = retained fish.
@@ -356,10 +358,15 @@ writeComps = function(inComps, fname = NULL, abins = NULL, lbins = NULL,
 
   if (!"fishyr" %in% colnames(uStrat)) stop("fishyr should be a column")
   if (!"fleet"  %in% colnames(uStrat)) stop("fleet should be a column")
+  
+  if("season" %in% names(inComps)){
+    use_month <- month[uStrat[, "season"]]
+  } else {
+    use_month <- month
+  }
+                                      
   uStrat <- data.frame(uStrat[, "fishyr"], 
-                       month = ifelse("season" %in% names(inComps), 
-                                      month[uStrat[, "season"]],
-                                      month),
+                       month = use_month,
                        uStrat[, 'fleet'])
   colnames(uStrat) <-  c("year", "month", "fleet")
 

--- a/R/writeComps.R
+++ b/R/writeComps.R
@@ -28,6 +28,9 @@
 #'   later. Note that \code{maxAge} is only used if \code{abins = NULL}, otherwise
 #'   fish are binned according to user specified bins irregardless of \code{maxAge}.
 #'   
+#' @param month Month for all observations. Defaults to 7. If input has multiple 
+#' seasons, this must be a vector of equal length to the number of seasons.
+#' 
 #' @param partition  Used by Stock Synthesis for length- or age-composition data
 #' where 0 = retained + discarded, 1= discarded, and 2 = retained fish.
 #' The default is to assume that these fish are retained only.
@@ -35,7 +38,7 @@
 #' and code should be updated accordingly if you really want 0.
 #' @param ageErr     Defaults to 1.
 #' 
-#' @param dummybins A logcial value specifying whether data outside of the
+#' @param dummybins A logical value specifying whether data outside of the
 #'   lower and upper \code{abins} or \code{lbins} should be added to dummy bins,
 #'   or be placed in the specified bins. Default is \code{TRUE}.  Dummy
 #'   bins are useful for determining whether the current bin structure
@@ -97,9 +100,16 @@
 #'
 ##############################################################################
 writeComps = function(inComps, fname = NULL, abins = NULL, lbins = NULL,
-                      maxAge = Inf, partition = 2, ageErr = 0, 
+                      maxAge = Inf, month = 7, partition = 2, ageErr = 0,
                       dummybins = FALSE, sum1 = FALSE, digits = 4,
                       overwrite = TRUE, verbose = FALSE) {
+
+  # Check month input vs seasons in data
+  if(max(inComps[["season"]]) != length(month)) {
+    stop("Input 'month' should have length equal to the maximum season:",
+    "\nmonth: ", month,
+    "\nseasons: ", paste(sort(unique(inComps[["season"]])), collapse = " "))
+  }
 
   # To stop warning of no visible binding b/c assign is used
   mComps <- NULL
@@ -346,7 +356,7 @@ writeComps = function(inComps, fname = NULL, abins = NULL, lbins = NULL,
   if (!"fishyr" %in% colnames(uStrat)) stop("fishyr should be a column")
   if (!"fleet"  %in% colnames(uStrat)) stop("fleet should be a column")
   uStrat <- data.frame(uStrat[, "fishyr"], 
-                       month = 1,
+                       month = month[uStrat[, "season"]],
                        uStrat[, 'fleet'])
   colnames(uStrat) <-  c("year", "month", "fleet")
 

--- a/man/writeComps.Rd
+++ b/man/writeComps.Rd
@@ -10,6 +10,7 @@ writeComps(
   abins = NULL,
   lbins = NULL,
   maxAge = Inf,
+  month = 7,
   partition = 2,
   ageErr = 0,
   dummybins = FALSE,
@@ -41,6 +42,9 @@ then those fish will be included in a plus group which you can investigate
 later. Note that \code{maxAge} is only used if \code{abins = NULL}, otherwise
 fish are binned according to user specified bins irregardless of \code{maxAge}.}
 
+\item{month}{Month for all observations. Defaults to 7. If input has multiple
+seasons, this must be a vector of equal length to the number of seasons.}
+
 \item{partition}{Used by Stock Synthesis for length- or age-composition data
 where 0 = retained + discarded, 1= discarded, and 2 = retained fish.
 The default is to assume that these fish are retained only.
@@ -49,7 +53,7 @@ and code should be updated accordingly if you really want 0.}
 
 \item{ageErr}{Defaults to 1.}
 
-\item{dummybins}{A logcial value specifying whether data outside of the
+\item{dummybins}{A logical value specifying whether data outside of the
 lower and upper \code{abins} or \code{lbins} should be added to dummy bins,
 or be placed in the specified bins. Default is \code{TRUE}.  Dummy
 bins are useful for determining whether the current bin structure
@@ -72,7 +76,7 @@ printing makes it easier to see if the data has errors and what was
 done to rectify them in the given function.
 Sorry, but the default is to always print to the screen,
 i.e., \code{verbose = TRUE}, so you do not miss out on anything.
-This is standard practice for packages in the nwfsc-assess organization.}
+This is standard practice for packages in the pfmc-assessments organization.}
 }
 \value{
 Appends data to the file given in \code{fname}.
@@ -130,5 +134,5 @@ were used in stratifying the data.
 \code{\link{getComps}}, \code{\link{doSexRatio}}
 }
 \author{
-Andi Stephens
+Andi Stephens, Chantel Wetzel, Kelli Johnson, Ian Taylor
 }


### PR DESCRIPTION
While working with Petrale data I realized that the status-quo `writeComps()` has month = 1 hard-wired for all comp data, even when there are multiple seasons. This change allows the user to choose a separate month for each season in seasonal models, as well as giving control of the month for annual models (with default to 7 instead of 1 since that seems to be the most common choice).  I tested this with an input that had 2 seasons and another with only 1.

Please modify as you wish.