### PR TITLE
fix writeComps() bug with CAAL columns

### DIFF
--- a/R/writeComps.R
+++ b/R/writeComps.R
@@ -276,6 +276,7 @@ writeComps = function(inComps, fname = NULL, abins = NULL, lbins = NULL,
   } else {
     # Overwrite the expansion value to match sample sizes for AAL
     # This should really be done in the getComps function
+    inComps$b <- inComps$bsamps
     inComps$f <- inComps$fsamps
     inComps$m <- inComps$msamps
     inComps$u <- inComps$usamps


### PR DESCRIPTION
For reasons that I don't understand, after updating PacFIN.Utilities today, I started getting `Error in x[[jj]][iseq] <- vjj : replacement has length zero` when running `writeComps()` for CAAL data. I tracked it down to a missing "b" column which is corrected by this Pull Request.

I don't know what caused the bug or what's going on in the area that I fixed, I was just following the pattern I see in the non-CAAL code immediately above. In general we never use vectors of both females and males for CAAL data, so an alternative solution would be to skip that option when writing CAAL data.

To replicate the error, get the petrale bds data off the NWFSC network (which @chantelwetzel-noaa created) and source this file https://github.com/pfmc-assessments/petrale/blob/main/R/process_pacfin_bds.R up through writing the CAAL data on line 430.