### PR TITLE
Adds ageing method 10 to Break and Burn category

### DIFF
--- a/R/codify_age_method.R
+++ b/R/codify_age_method.R
@@ -21,7 +21,8 @@
 #' * 4-thin section;
 #' * 5-optical scanner;
 #' * 6-length;
-#' * 9-unable
+#' * 9-unable;
+#' * 10-break and bake;
 #'
 #'  ## California Department of Fish and Wildlife
 #' * B-break and burn;
@@ -54,6 +55,7 @@ codify_age_method <- function(x) {
     x == 6 ~ "L",
     x == "L" ~ "L",
     x == "M" ~ "M",
+    x == 10 ~ "B",
     x %in% all_NA ~ NA_character_,
     is.na(x) ~ NA_character_,
     TRUE ~ NA_character_

--- a/man/codify_age_method.Rd
+++ b/man/codify_age_method.Rd
@@ -38,7 +38,8 @@ and burn can be "B", "BB", or 1.
 \item 4-thin section;
 \item 5-optical scanner;
 \item 6-length;
-\item 9-unable
+\item 9-unable;
+\item 10-break and bake;
 }
 }
 


### PR DESCRIPTION
Really it is break and bake but for our purposes that is equivalent to break and burn. This code will be specific to ODFW, where Betty likes to bake them rather than burn them.

Resolves #121

Tasks: @okenk can you test this with your PacFIN data pull to make sure that the limited changes are sufficient. I think all that was needed was coding the break and bake samples to break and burn so that they were not marked as NA and then excluded.