### PR TITLE
Change how catches are matched with Pdata in getExpansion_2

### DIFF
--- a/R/getExpansion_2.R
+++ b/R/getExpansion_2.R
@@ -176,7 +176,8 @@ getExpansion_2 <- function(Pdata,
     dplyr::ungroup() %>%
     # Matching rows in Pdata with Catch[, "Year"] and correct column in Catch
     dplyr::left_join(Catch_long, by = c('fishyr' = names(Catch_long)[yearcol],
-                                        'stratification' = 'stratification'))
+                                        'stratification' = 'stratification'), 
+                     relationship = 'many-to-one')
   
   # Find which trips don't have catch values associated with them
   trips_without_catch <- dplyr::filter(tows, is.na(catch))


### PR DESCRIPTION
While working up yellowtail data, I got an error when I ran `getExpansion_2()`. I traced this to the column `tows$catch`, which for some reason was being stored as a list instead of a numeric vector.

Rather than try to understand why the existing code was doing this, it was faster for me to figure out what the code was doing and rewrite it using "tidier" practices. These edits to the function:

1. Use `tidyr::pivot_longer()` to create a `Catch_long` data frame
2. Match the observations in `Pdata` to the appropriate row in `Catch_long` using `dplyr::left_join()` instead of using `apply()` and `match()` on the wide `Catch` data frame.

The output should be the same, but I no longer get an error when I run this function in my environment on my data. (Though note that because I could not run the function previously, I have not tested to ensure the output is identical.)

(Also, I swear I did not know I would have this problem and solve it in this way when I created #136! 😆)